### PR TITLE
Fix condition for binary check when no old file exists

### DIFF
--- a/src/OutputChecker.cs
+++ b/src/OutputChecker.cs
@@ -324,7 +324,7 @@ namespace CheckTestOutput
 
             var filename = Path.Combine(CheckDirectory, (checkName == null ? method : $"{method}-{checkName}") + "." + fileExtension);
 
-            if (GetOldBinaryContent(filename).SequenceEqual(outputBytes))
+            if (GetOldBinaryContent(filename)?.SequenceEqual(outputBytes) == true)
             {
                 // fine! Just check that the file is not changed - if it is changed or deleted, we rewrite
                 if (IsModified(filename))


### PR DESCRIPTION
Binary check fails if there is no "old" file to be compared to. Method `GetOldBinaryContent(filename)` called from `CheckOutputBinaryCore` gets `null` as result, then validation in `SequenceEqual` extension method fails.

Steps to reproduce:
- delete 4 files BinaryTest.* from `testoutputs` directory
- run tests
- 4 test in `BinaryTest` fail with this stack trace:
```stacktrace
Value cannot be null. (Parameter 'first')
   at System.Linq.ThrowHelper.ThrowArgumentNullException(ExceptionArgument argument)
   at System.Linq.Enumerable.SequenceEqual[TSource](IEnumerable`1 first, IEnumerable`1 second, IEqualityComparer`1 comparer)
   at System.Linq.Enumerable.SequenceEqual[TSource](IEnumerable`1 first, IEnumerable`1 second)
   at CheckTestOutput.OutputChecker.CheckOutputBinaryCore(Byte[] outputBytes, String checkName, String method, String fileExtension) in C:\Users\LubosHladik\repos\github\CheckTestOutput\src\OutputChecker.cs:line 327
   at CheckTestOutput.BasicChecks.CheckBinary(OutputChecker t, Byte[] output, String checkName, String fileExtension, String memberName, String sourceFilePath) in C:\Users\LubosHladik\repos\github\CheckTestOutput\src\BasicChecks.cs:line 36
```