### PR TITLE
Added an option to have multiple valid outputs

### DIFF
--- a/src/BasicChecks.cs
+++ b/src/BasicChecks.cs
@@ -13,13 +13,15 @@ namespace CheckTestOutput
             string checkName = null,
             string fileExtension = "txt",
             [System.Runtime.CompilerServices.CallerMemberName] string memberName = null,
-            [System.Runtime.CompilerServices.CallerFilePath] string sourceFilePath = null)
+            [System.Runtime.CompilerServices.CallerFilePath] string sourceFilePath = null,
+            bool allowAlternatives = false)
         {
             t.CheckOutputCore(
                 output,
                 checkName,
                 $"{Path.GetFileNameWithoutExtension(sourceFilePath)}.{memberName}",
-                fileExtension
+                fileExtension,
+                allowAlternatives
             );
         }
 


### PR DESCRIPTION
I had a case where multiple outputs were valid. Therefore, I've added an optional parameter called `allowAlternatives` and added support for having multiple output files with suffixes `alt000`, `alt001`, ...